### PR TITLE
Refactorings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/populate-cache
+      - name: Populate cache
+        uses: ./.github/actions/populate-cache
 
   build-and-test:
     runs-on: ubuntu-latest
@@ -147,10 +148,6 @@ jobs:
             -Dsonar.login=${SONAR_TOKEN} \
             sonar
 
-      - name: Cancel Build
-        if: ${{ failure() }}
-        uses: andymckay/cancel-action@0.3
-
   owasp:
     runs-on: ubuntu-latest
 
@@ -162,14 +159,14 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/owasp
+      - name: OWAS Dependency check
+        uses: ./.github/actions/owasp
 
   integration-tests:
     runs-on: ubuntu-latest
 
     needs:
-      - sonar
-      - owasp
+      - build-and-test
 
     steps:
       - name: Git checkout

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/populate-cache
+      - name: Populate cache
+        uses: ./.github/actions/populate-cache
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-cve-scan.yml
+++ b/.github/workflows/nightly-cve-scan.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/populate-cache
+      - name: Populate cache
+        uses: ./.github/actions/populate-cache
 
   owasp:
     runs-on: ubuntu-latest

--- a/src/main/java/cde/chameleon/api/ApiErrorDto.java
+++ b/src/main/java/cde/chameleon/api/ApiErrorDto.java
@@ -1,13 +1,18 @@
 package cde.chameleon.api;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 @Data
+@Jacksonized
+@Builder(access = AccessLevel.PACKAGE)
 public class ApiErrorDto {
 
     @Schema(description = "error message", example = "An error occurred!")
@@ -15,10 +20,6 @@ public class ApiErrorDto {
 
     @Schema(description = "errors", example = "[\"error1\", \"error2\"]")
     private List<String> errors;
-
-    public ApiErrorDto() {
-        this("");
-    }
 
     public ApiErrorDto(String message) {
         this(message, Collections.emptyList());

--- a/src/main/java/cde/chameleon/config/WebSecurityConfig.java
+++ b/src/main/java/cde/chameleon/config/WebSecurityConfig.java
@@ -5,9 +5,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -64,15 +66,18 @@ public class WebSecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.oauth2ResourceServer().jwt().jwtAuthenticationConverter(jwtToAuthenticationTokenConverter());
-        http.anonymous();
-        http.cors().configurationSource(corsConfigurationSource());
+        http.oauth2ResourceServer(resourceServer ->
+            resourceServer.jwt(jwt ->
+                jwt.jwtAuthenticationConverter(jwtToAuthenticationTokenConverter())));
+        http.anonymous(Customizer.withDefaults());
+        http.cors(cors -> cors.configurationSource(corsConfigurationSource()));
 
         // disable sessions (i.e. service is stateless)
-        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http.sessionManagement(sessionManager ->
+            sessionManager.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         // disable CSRF because authentication and authorization is not based on cookies
-        http.csrf().disable();
+        http.csrf(AbstractHttpConfigurer::disable);
 
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/**").authenticated()

--- a/src/test/java/cde/chameleon/ChameleonArchitectureTest.java
+++ b/src/test/java/cde/chameleon/ChameleonArchitectureTest.java
@@ -106,6 +106,6 @@ class ChameleonArchitectureTest {
                     .onlyDependOnClassesThat()
                     .resideInAnyPackage(
                             "cde.chameleon.api", "java..", "jakarta..", "org.springframework..",
-                            "io.swagger..", "org.slf4j..", "lombok..", "org.apache.commons..")
+                            "io.swagger..", "org.slf4j..", "lombok..", "org.apache.commons..", "..jackson..")
                     .as("The cross-cutting concerns for APIs must not depend on other packages of project Chameleon.");
 }

--- a/src/test/resources/owasp-dependency-check.xml
+++ b/src/test/resources/owasp-dependency-check.xml
@@ -4,8 +4,4 @@
         <notes>Spring Boot application only use SnakeYaml to parse application.yaml files, which should be trusted.</notes>
         <cve>CVE-2022-1471</cve>
     </suppress>
-    <suppress>
-        <notes>We acknowledge this CVE. Right now, we cannot do anything about it; there is no fix yet.</notes>
-        <cve>CVE-2022-45688</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
- Remove deprecated calls in WebSecurityConfig
- Add jackson-registered builder to ApiErrorDto
- Run integration tests after unit tests, not after owasp and sonar
- Give names to all github-actions
- Remove workflow cancel action
- Remove outdated suppression from owasp-dependency-check.xml