### PR TITLE
Update container images

### DIFF
--- a/localdeployment/docker-compose.yml
+++ b/localdeployment/docker-compose.yml
@@ -1,10 +1,9 @@
-version: "3.8"
 services:
 
   # apache activemq-artemis
   # -- uncomment if needed --
 #  artemis:
-#    image: quay.io/artemiscloud/activemq-artemis-broker:artemis.2.32.0
+#    image: quay.io/arkmq-org/activemq-artemis-broker:artemis.2.40.0
 #    container_name: artemis
 #    ports:
 #      - "58161:8161"
@@ -17,7 +16,7 @@ services:
 
   # database for the chameleon application
   chameleon-database:
-    image: docker.io/postgres:16.2-alpine3.19
+    image: docker.io/postgres:17.5-alpine3.22
     container_name: chameleon-database
     volumes:
       - ${REMOTE_LOCALDEPLOYMENT_DIR:-.}/chameleon-database:/docker-entrypoint-initdb.d
@@ -31,7 +30,7 @@ services:
   # pgadmin4 web UI - to interact with the postgres databases
   # -- uncomment if needed --
 #  pgadmin4:
-#    image: docker.io/dpage/pgadmin4:8.3
+#    image: docker.io/dpage/pgadmin4:9.4.0
 #    volumes:
 #      - ${REMOTE_LOCALDEPLOYMENT_DIR:-.}/pgadmin4/pgadmin4/servers.json:/pgadmin4/servers.json:ro
 #    depends_on:
@@ -45,7 +44,7 @@ services:
 
   # keycloak
   keycloak:
-    image: quay.io/keycloak/keycloak:25.0.0-0
+    image: quay.io/keycloak/keycloak:26.2.5-0
     container_name: keycloak
     volumes:
       - ${REMOTE_LOCALDEPLOYMENT_DIR:-.}/keycloak/realm-chameleon.json:/opt/keycloak/data/import/realm-chameleon.json:ro
@@ -66,7 +65,7 @@ services:
 
   # nginx as reverse-proxy
   nginx:
-    image: docker.io/nginx:1.25.4-alpine-slim
+    image: docker.io/nginx:1.27.4-alpine-slim
     container_name: nginx
     extra_hosts:
       - hostip:host-gateway


### PR DESCRIPTION
- artemis from `quay.io/artemiscloud/activemq-artemis-broker:artemis.2.32.0` to `quay.io/arkmq-org/activemq-artemis-broker:artemis.2.40.0`
- postgres from `docker.io/postgres:16.2-alpine3.19` to `docker.io/postgres:17.5-alpine3.22`
- pgadmin4 from `docker.io/dpage/pgadmin4:8.3` to `docker.io/dpage/pgadmin4:9.4.0`
- keycloak from `quay.io/keycloak/keycloak:25.0.0-0` to `quay.io/keycloak/keycloak:26.2.5-0`
- nginx from `docker.io/nginx:1.25.4-alpine-slim` to `docker.io/nginx:1.27.4-alpine-slim`
- remove `version` from `docker-compose.yml` since it is obsolete